### PR TITLE
remove 'sperm' from verified words

### DIFF
--- a/verified-words.txt
+++ b/verified-words.txt
@@ -10703,7 +10703,6 @@ spend
 spending
 spends
 spent
-sperm
 sphere
 spheres
 spherical
@@ -12904,3 +12903,4 @@ thebestcodes
 the-best-codes
 best_codes
 AGI
+


### PR DESCRIPTION
I suppose that whether 'sperm' is OK for kids to see depends on the context, but I used this list and somebody objected to getting the word 'sperm', so maybe it's best just to remove it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the list of verified words by removing the word "sperm".
  * Minor formatting adjustment with a blank line at the end of the list.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->